### PR TITLE
feat: add installation wizard

### DIFF
--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+
+class InstallController extends Controller
+{
+    public function show()
+    {
+        if (file_exists(storage_path('installed.lock'))) {
+            return redirect('/login');
+        }
+
+        $extensions = ['pdo', 'openssl', 'mbstring', 'curl'];
+        $missing = array_filter($extensions, fn ($ext) => !extension_loaded($ext));
+
+        return view('install', [
+            'missing' => $missing,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        if (file_exists(storage_path('installed.lock'))) {
+            return redirect('/login');
+        }
+
+        $data = $request->validate([
+            'db_host' => 'required',
+            'db_port' => 'required',
+            'db_database' => 'required',
+            'db_username' => 'required',
+            'db_password' => 'nullable',
+            'smtp_host' => 'required',
+            'smtp_port' => 'required',
+            'smtp_username' => 'required',
+            'smtp_password' => 'required',
+            'admin_email' => 'required|email',
+            'admin_password' => 'required|min:6',
+        ]);
+
+        $env = [
+            'APP_NAME' => 'Laravel',
+            'APP_ENV' => 'production',
+            'APP_KEY' => 'base64:' . base64_encode(random_bytes(32)),
+            'APP_DEBUG' => 'false',
+            'APP_URL' => url('/'),
+            'DB_CONNECTION' => 'mysql',
+            'DB_HOST' => $data['db_host'],
+            'DB_PORT' => $data['db_port'],
+            'DB_DATABASE' => $data['db_database'],
+            'DB_USERNAME' => $data['db_username'],
+            'DB_PASSWORD' => $data['db_password'],
+            'MAIL_MAILER' => 'smtp',
+            'MAIL_HOST' => $data['smtp_host'],
+            'MAIL_PORT' => $data['smtp_port'],
+            'MAIL_USERNAME' => $data['smtp_username'],
+            'MAIL_PASSWORD' => $data['smtp_password'],
+        ];
+
+        $envContent = '';
+        foreach ($env as $key => $value) {
+            $envContent .= $key . '="' . $value . ""\n";
+        }
+
+        file_put_contents(base_path('.env'), $envContent);
+        Artisan::call('config:clear');
+
+        Config::set('database.connections.mysql.host', $data['db_host']);
+        Config::set('database.connections.mysql.port', $data['db_port']);
+        Config::set('database.connections.mysql.database', $data['db_database']);
+        Config::set('database.connections.mysql.username', $data['db_username']);
+        Config::set('database.connections.mysql.password', $data['db_password']);
+
+        Config::set('mail.mailers.smtp.host', $data['smtp_host']);
+        Config::set('mail.mailers.smtp.port', $data['smtp_port']);
+        Config::set('mail.mailers.smtp.username', $data['smtp_username']);
+        Config::set('mail.mailers.smtp.password', $data['smtp_password']);
+
+        try {
+            DB::connection()->getPdo();
+        } catch (\Exception $e) {
+            return back()->withErrors(['db' => $e->getMessage()]);
+        }
+
+        try {
+            Mail::raw('Installation test', function ($message) use ($data) {
+                $message->to($data['admin_email']);
+            });
+        } catch (\Exception $e) {
+            return back()->withErrors(['smtp' => $e->getMessage()]);
+        }
+
+        Artisan::call('migrate', ['--seed' => true]);
+
+        User::create([
+            'name' => 'Admin',
+            'email' => $data['admin_email'],
+            'password' => Hash::make($data['admin_password']),
+            'is_admin' => true,
+        ]);
+
+        touch(storage_path('installed.lock'));
+
+        return redirect('/login');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'is_admin',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+}

--- a/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/database/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->boolean('is_admin')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        //
+    }
+}

--- a/resources/views/install.blade.php
+++ b/resources/views/install.blade.php
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Installer</title>
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+</head>
+<body>
+    <h1>Installation Wizard</h1>
+    @if($missing)
+        <div class="alert">
+            Missing PHP extensions: {{ implode(', ', $missing) }}
+        </div>
+    @endif
+    <form method="POST" action="{{ url('/install') }}">
+        @csrf
+        <h2>Database</h2>
+        <input type="text" name="db_host" placeholder="DB Host" value="{{ old('db_host', '127.0.0.1') }}" required>
+        <input type="text" name="db_port" placeholder="DB Port" value="{{ old('db_port', '3306') }}" required>
+        <input type="text" name="db_database" placeholder="DB Name" value="{{ old('db_database') }}" required>
+        <input type="text" name="db_username" placeholder="DB Username" value="{{ old('db_username') }}" required>
+        <input type="password" name="db_password" placeholder="DB Password">
+        <h2>SMTP</h2>
+        <input type="text" name="smtp_host" placeholder="SMTP Host" value="{{ old('smtp_host') }}" required>
+        <input type="text" name="smtp_port" placeholder="SMTP Port" value="{{ old('smtp_port', '587') }}" required>
+        <input type="text" name="smtp_username" placeholder="SMTP Username" value="{{ old('smtp_username') }}" required>
+        <input type="password" name="smtp_password" placeholder="SMTP Password" required>
+        <h2>Admin User</h2>
+        <input type="email" name="admin_email" placeholder="Admin Email" value="{{ old('admin_email') }}" required>
+        <input type="password" name="admin_password" placeholder="Admin Password" required>
+        <button type="submit">Install</button>
+    </form>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,5 +2,15 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\InstallController;
 
-Route::get('/', HomeController::class);
+Route::get('/', function () {
+    if (!file_exists(storage_path('installed.lock'))) {
+        return redirect('/install');
+    }
+
+    return app(HomeController::class)();
+});
+
+Route::get('/install', [InstallController::class, 'show'])->name('install');
+Route::post('/install', [InstallController::class, 'store']);

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -6,9 +6,9 @@ use Tests\TestCase;
 
 class HomeTest extends TestCase
 {
-    public function test_home_page(): void
+    public function test_redirects_to_installer_when_not_installed(): void
     {
         $response = $this->get('/');
-        $response->assertStatus(200);
+        $response->assertRedirect('/install');
     }
 }

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class InstallTest extends TestCase
+{
+    public function test_installation_page_is_accessible_when_not_installed(): void
+    {
+        $response = $this->get('/install');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add installation routes and controller to handle first-run setup
- create simple wizard view for database and SMTP configuration
- add basic User model and migration used during install

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689a6409b5e4832282806c252714316e