### PR TITLE
Add user roles and basic RBAC gates

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,7 +14,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'is_admin',
+        'role',
+        'locale',
     ];
 
     protected $hidden = [

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+use App\Models\User;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Gate::define('admin', fn (User $user) => $user->role === 'admin');
+        Gate::define('manager', fn (User $user) => in_array($user->role, ['admin', 'manager']));
+        Gate::define('client', fn (User $user) => in_array($user->role, ['admin', 'manager', 'client']));
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -15,6 +15,7 @@ return [
 
     'providers' => [
         App\Providers\RouteServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
     ],
 
     'aliases' => [

--- a/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/database/migrations/2024_01_01_000000_create_users_table.php
@@ -12,7 +12,8 @@ return new class extends Migration {
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->boolean('is_admin')->default(false);
+            $table->enum('role', ['admin', 'manager', 'client'])->default('client');
+            $table->string('locale')->default('en');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- expand users migration with role and locale columns
- update User model to expose role and locale
- register role-based gates in AuthServiceProvider

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/bh/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_b_689a651932a483228127450d8287bb62