### PR TITLE
Add clients CRM module

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Client;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('can:manager');
+    }
+
+    public function index(Request $request)
+    {
+        $query = Client::query();
+
+        if ($search = $request->get('search')) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%$search%")
+                  ->orWhere('contact_email', 'like', "%$search%")
+                  ->orWhere('contact_phone', 'like', "%$search%");
+            });
+        }
+
+        if ($status = $request->get('status')) {
+            $query->where('status', $status);
+        }
+
+        if ($tags = $request->get('tags')) {
+            $tagsArr = array_filter(array_map('trim', explode(',', $tags)));
+            foreach ($tagsArr as $tag) {
+                $query->whereJsonContains('tags', $tag);
+            }
+        }
+
+        $clients = $query->paginate(15);
+
+        return view('clients.index', compact('clients'));
+    }
+
+    public function create()
+    {
+        return view('clients.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'status' => 'required|in:lead,active,paused,archived',
+            'contact_email' => 'nullable|email',
+            'contact_phone' => 'nullable|string|max:255',
+            'notes' => 'nullable|string',
+            'tags' => 'nullable|string',
+        ]);
+
+        $data['tags'] = $this->parseTags($data['tags'] ?? '');
+
+        $client = Client::create($data);
+
+        return redirect()->route('clients.show', $client);
+    }
+
+    public function show(Client $client)
+    {
+        $client->load('activities');
+        return view('clients.show', compact('client'));
+    }
+
+    public function edit(Client $client)
+    {
+        return view('clients.edit', compact('client'));
+    }
+
+    public function update(Request $request, Client $client)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'status' => 'required|in:lead,active,paused,archived',
+            'contact_email' => 'nullable|email',
+            'contact_phone' => 'nullable|string|max:255',
+            'notes' => 'nullable|string',
+            'tags' => 'nullable|string',
+        ]);
+
+        $data['tags'] = $this->parseTags($data['tags'] ?? '');
+
+        $client->update($data);
+
+        return redirect()->route('clients.show', $client);
+    }
+
+    public function destroy(Client $client)
+    {
+        $client->delete();
+        return redirect()->route('clients.index');
+    }
+
+    public function storeActivity(Request $request, Client $client)
+    {
+        $data = $request->validate([
+            'description' => 'required|string',
+        ]);
+
+        $client->activities()->create($data);
+
+        return redirect()->route('clients.show', $client);
+    }
+
+    private function parseTags(string $tags): array
+    {
+        return array_filter(array_map('trim', explode(',', $tags)));
+    }
+}

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'status',
+        'contact_email',
+        'contact_phone',
+        'notes',
+        'tags',
+    ];
+
+    protected $casts = [
+        'tags' => 'array',
+    ];
+
+    public function activities()
+    {
+        return $this->hasMany(ClientActivity::class);
+    }
+}

--- a/app/Models/ClientActivity.php
+++ b/app/Models/ClientActivity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClientActivity extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'client_id',
+        'description',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+}

--- a/database/migrations/2024_01_01_010000_create_clients_table.php
+++ b/database/migrations/2024_01_01_010000_create_clients_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->enum('status', ['lead', 'active', 'paused', 'archived'])->default('lead');
+            $table->string('contact_email')->nullable();
+            $table->string('contact_phone')->nullable();
+            $table->text('notes')->nullable();
+            $table->json('tags')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clients');
+    }
+};

--- a/database/migrations/2024_01_01_010100_create_client_activities_table.php
+++ b/database/migrations/2024_01_01_010100_create_client_activities_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('client_activities', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained()->cascadeOnDelete();
+            $table->text('description');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_activities');
+    }
+};

--- a/resources/views/clients/create.blade.php
+++ b/resources/views/clients/create.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create Client</h1>
+
+<form method="post" action="{{ route('clients.store') }}">
+    @csrf
+    <div><input type="text" name="name" value="{{ old('name') }}" placeholder="Name"></div>
+    <div>
+        <select name="status">
+            @foreach(['lead','active','paused','archived'] as $st)
+                <option value="{{ $st }}" @selected(old('status')===$st)>{{ ucfirst($st) }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div><input type="email" name="contact_email" value="{{ old('contact_email') }}" placeholder="Email"></div>
+    <div><input type="text" name="contact_phone" value="{{ old('contact_phone') }}" placeholder="Phone"></div>
+    <div><textarea name="notes" placeholder="Notes">{{ old('notes') }}</textarea></div>
+    <div><input type="text" name="tags" value="{{ old('tags') }}" placeholder="Tags"></div>
+    <button type="submit">Save</button>
+</form>
+@endsection

--- a/resources/views/clients/edit.blade.php
+++ b/resources/views/clients/edit.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Client</h1>
+
+<form method="post" action="{{ route('clients.update', $client) }}">
+    @csrf
+    @method('PUT')
+    <div><input type="text" name="name" value="{{ old('name', $client->name) }}" placeholder="Name"></div>
+    <div>
+        <select name="status">
+            @foreach(['lead','active','paused','archived'] as $st)
+                <option value="{{ $st }}" @selected(old('status', $client->status)===$st)>{{ ucfirst($st) }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div><input type="email" name="contact_email" value="{{ old('contact_email', $client->contact_email) }}" placeholder="Email"></div>
+    <div><input type="text" name="contact_phone" value="{{ old('contact_phone', $client->contact_phone) }}" placeholder="Phone"></div>
+    <div><textarea name="notes" placeholder="Notes">{{ old('notes', $client->notes) }}</textarea></div>
+    <div><input type="text" name="tags" value="{{ old('tags', implode(', ', $client->tags ?? [])) }}" placeholder="Tags"></div>
+    <button type="submit">Update</button>
+</form>
+@endsection

--- a/resources/views/clients/index.blade.php
+++ b/resources/views/clients/index.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Clients</h1>
+
+<form method="get" action="{{ route('clients.index') }}">
+    <input type="text" name="search" value="{{ request('search') }}" placeholder="Search">
+    <select name="status">
+        <option value="">Any status</option>
+        @foreach(['lead','active','paused','archived'] as $st)
+            <option value="{{ $st }}" @selected(request('status')===$st)>{{ ucfirst($st) }}</option>
+        @endforeach
+    </select>
+    <input type="text" name="tags" value="{{ request('tags') }}" placeholder="Tags">
+    <button type="submit">Filter</button>
+</form>
+
+<a href="{{ route('clients.create') }}">Create Client</a>
+
+<ul>
+@foreach ($clients as $client)
+    <li><a href="{{ route('clients.show', $client) }}">{{ $client->name }}</a> ({{ $client->status }})</li>
+@endforeach
+</ul>
+
+{{ $clients->withQueryString()->links() }}
+@endsection

--- a/resources/views/clients/show.blade.php
+++ b/resources/views/clients/show.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>{{ $client->name }}</h1>
+<p>Status: {{ $client->status }}</p>
+<p>Email: {{ $client->contact_email }}</p>
+<p>Phone: {{ $client->contact_phone }}</p>
+<p>Tags: {{ implode(', ', $client->tags ?? []) }}</p>
+<p>Notes: {{ $client->notes }}</p>
+
+<h2>Timeline</h2>
+<ul>
+@foreach ($client->activities as $activity)
+    <li>{{ $activity->created_at }} - {{ $activity->description }}</li>
+@endforeach
+</ul>
+
+<form method="post" action="{{ route('clients.activities.store', $client) }}">
+    @csrf
+    <input type="text" name="description" placeholder="New activity">
+    <button type="submit">Add</button>
+</form>
+
+<a href="{{ route('clients.edit', $client) }}">Edit</a>
+<form method="post" action="{{ route('clients.destroy', $client) }}" style="display:inline">
+    @csrf
+    @method('DELETE')
+    <button type="submit">Delete</button>
+</form>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name') }}</title>
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+</head>
+<body>
+    @yield('content')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\InstallController;
+use App\Http\Controllers\ClientController;
 
 Route::get('/', function () {
     if (!file_exists(storage_path('installed.lock'))) {
@@ -14,3 +15,6 @@ Route::get('/', function () {
 
 Route::get('/install', [InstallController::class, 'show'])->name('install');
 Route::post('/install', [InstallController::class, 'store']);
+
+Route::resource('clients', ClientController::class);
+Route::post('clients/{client}/activities', [ClientController::class, 'storeActivity'])->name('clients.activities.store');


### PR DESCRIPTION
## Summary
- add migrations and models for clients and their activities
- implement client CRUD with search, filtering and activity timeline
- create simple views and routes for managing clients

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689a662d8a8083228b264afb4c71c4dd