### PR TITLE
Add project and task management module with Kanban board

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ProjectController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('can:manager')->except(['index', 'show']);
+        $this->middleware('can:client')->only(['index', 'show']);
+    }
+
+    public function index()
+    {
+        $query = Project::query();
+        if (Auth::user()->role === 'client') {
+            $query->where('client_id', Auth::id());
+        }
+        $projects = $query->paginate(15);
+        return view('projects.index', compact('projects'));
+    }
+
+    public function create()
+    {
+        return view('projects.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|exists:clients,id',
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'status' => 'required|in:planned,active,on-hold,completed,archived',
+            'priority' => 'nullable|integer',
+            'owner_id' => 'nullable|exists:users,id',
+        ]);
+
+        $project = Project::create($data);
+        return redirect()->route('projects.show', $project);
+    }
+
+    public function show(Project $project)
+    {
+        if (Auth::user()->role === 'client' && $project->client_id !== Auth::id()) {
+            abort(403);
+        }
+        $tasks = $project->tasks()->orderBy('priority')->get()->groupBy('status');
+        return view('projects.show', compact('project', 'tasks'));
+    }
+
+    public function edit(Project $project)
+    {
+        return view('projects.edit', compact('project'));
+    }
+
+    public function update(Request $request, Project $project)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|exists:clients,id',
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'status' => 'required|in:planned,active,on-hold,completed,archived',
+            'priority' => 'nullable|integer',
+            'owner_id' => 'nullable|exists:users,id',
+        ]);
+
+        $project->update($data);
+        return redirect()->route('projects.show', $project);
+    }
+
+    public function destroy(Project $project)
+    {
+        $project->delete();
+        return redirect()->route('projects.index');
+    }
+}

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use App\Models\Task;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TaskController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('can:manager')->except(['store']);
+        $this->middleware('can:client')->only(['store']);
+    }
+
+    public function store(Request $request, Project $project)
+    {
+        if (Auth::user()->role === 'client' && $project->client_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'status' => 'required|in:todo,in_progress,review,done',
+            'priority' => 'nullable|integer',
+            'assignee_id' => 'nullable|exists:users,id',
+            'due_at' => 'nullable|date',
+        ]);
+
+        $project->tasks()->create($data);
+        return redirect()->route('projects.show', $project);
+    }
+
+    public function edit(Project $project, Task $task)
+    {
+        return view('tasks.edit', compact('project', 'task'));
+    }
+
+    public function update(Request $request, Project $project, Task $task)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'status' => 'required|in:todo,in_progress,review,done',
+            'priority' => 'nullable|integer',
+            'assignee_id' => 'nullable|exists:users,id',
+            'due_at' => 'nullable|date',
+        ]);
+
+        $task->update($data);
+        return redirect()->route('projects.show', $project);
+    }
+
+    public function destroy(Project $project, Task $task)
+    {
+        $task->delete();
+        return redirect()->route('projects.show', $project);
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Project extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'client_id',
+        'name',
+        'description',
+        'status',
+        'priority',
+        'owner_id',
+    ];
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class);
+    }
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Task extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'title',
+        'description',
+        'status',
+        'priority',
+        'assignee_id',
+        'due_at',
+    ];
+
+    protected $casts = [
+        'due_at' => 'datetime',
+    ];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+}

--- a/database/migrations/2024_01_01_020000_create_projects_table.php
+++ b/database/migrations/2024_01_01_020000_create_projects_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->enum('status', ['planned', 'active', 'on-hold', 'completed', 'archived'])->default('planned');
+            $table->integer('priority')->default(0);
+            $table->foreignId('owner_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('projects');
+    }
+};

--- a/database/migrations/2024_01_01_020100_create_tasks_table.php
+++ b/database/migrations/2024_01_01_020100_create_tasks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->enum('status', ['todo', 'in_progress', 'review', 'done'])->default('todo');
+            $table->integer('priority')->default(0);
+            $table->foreignId('assignee_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('due_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tasks');
+    }
+};

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -7,3 +7,7 @@ body {
     font-size: 1.5rem;
     color: #333;
 }
+
+.kanban { display: flex; gap: 1rem; }
+.kanban-column { flex: 1; background: #f4f4f4; padding: 0.5rem; }
+.kanban-item { background: #fff; margin-bottom: 0.5rem; padding: 0.5rem; border: 1px solid #ddd; }

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create Project</h1>
+<form method="post" action="{{ route('projects.store') }}">
+    @csrf
+    <label>Client ID
+        <input type="number" name="client_id" value="{{ old('client_id') }}">
+    </label><br>
+    <label>Name
+        <input type="text" name="name" value="{{ old('name') }}">
+    </label><br>
+    <label>Description
+        <textarea name="description">{{ old('description') }}</textarea>
+    </label><br>
+    <label>Status
+        <select name="status">
+            @foreach(['planned','active','on-hold','completed','archived'] as $st)
+                <option value="{{ $st }}" @selected(old('status')===$st)>{{ ucfirst($st) }}</option>
+            @endforeach
+        </select>
+    </label><br>
+    <label>Priority
+        <input type="number" name="priority" value="{{ old('priority',0) }}">
+    </label><br>
+    <label>Owner ID
+        <input type="number" name="owner_id" value="{{ old('owner_id') }}">
+    </label><br>
+    <button type="submit">Save</button>
+</form>
+@endsection

--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Project</h1>
+<form method="post" action="{{ route('projects.update', $project) }}">
+    @csrf
+    @method('PUT')
+    <label>Client ID
+        <input type="number" name="client_id" value="{{ old('client_id', $project->client_id) }}">
+    </label><br>
+    <label>Name
+        <input type="text" name="name" value="{{ old('name', $project->name) }}">
+    </label><br>
+    <label>Description
+        <textarea name="description">{{ old('description', $project->description) }}</textarea>
+    </label><br>
+    <label>Status
+        <select name="status">
+            @foreach(['planned','active','on-hold','completed','archived'] as $st)
+                <option value="{{ $st }}" @selected(old('status', $project->status)===$st)>{{ ucfirst($st) }}</option>
+            @endforeach
+        </select>
+    </label><br>
+    <label>Priority
+        <input type="number" name="priority" value="{{ old('priority', $project->priority) }}">
+    </label><br>
+    <label>Owner ID
+        <input type="number" name="owner_id" value="{{ old('owner_id', $project->owner_id) }}">
+    </label><br>
+    <button type="submit">Save</button>
+</form>
+@endsection

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Projects</h1>
+
+<a href="{{ route('projects.create') }}">Create Project</a>
+
+<ul>
+@foreach ($projects as $project)
+    <li><a href="{{ route('projects.show', $project) }}">{{ $project->name }}</a> ({{ $project->status }})</li>
+@endforeach
+</ul>
+
+{{ $projects->links() }}
+@endsection

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>{{ $project->name }}</h1>
+<p>Status: {{ $project->status }}</p>
+<p>Priority: {{ $project->priority }}</p>
+<p>{{ $project->description }}</p>
+
+<div class="kanban">
+@foreach(['todo','in_progress','review','done'] as $st)
+    <div class="kanban-column">
+        <h3>{{ ucfirst(str_replace('_',' ', $st)) }}</h3>
+        @foreach(($tasks[$st] ?? []) as $task)
+            <div class="kanban-item">
+                <a href="{{ route('projects.tasks.edit', [$project, $task]) }}">{{ $task->title }}</a>
+            </div>
+        @endforeach
+    </div>
+@endforeach
+</div>
+
+<h3>Add Task</h3>
+<form method="post" action="{{ route('projects.tasks.store', $project) }}">
+    @csrf
+    <label>Title
+        <input type="text" name="title" value="{{ old('title') }}">
+    </label>
+    <label>Status
+        <select name="status">
+            @foreach(['todo','in_progress','review','done'] as $st)
+                <option value="{{ $st }}" @selected(old('status')===$st)>{{ ucfirst(str_replace('_',' ', $st)) }}</option>
+            @endforeach
+        </select>
+    </label>
+    <button type="submit">Add</button>
+</form>
+@endsection

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Task</h1>
+<form method="post" action="{{ route('projects.tasks.update', [$project, $task]) }}">
+    @csrf
+    @method('PUT')
+    <label>Title
+        <input type="text" name="title" value="{{ old('title', $task->title) }}">
+    </label><br>
+    <label>Description
+        <textarea name="description">{{ old('description', $task->description) }}</textarea>
+    </label><br>
+    <label>Status
+        <select name="status">
+            @foreach(['todo','in_progress','review','done'] as $st)
+                <option value="{{ $st }}" @selected(old('status', $task->status)===$st)>{{ ucfirst(str_replace('_',' ', $st)) }}</option>
+            @endforeach
+        </select>
+    </label><br>
+    <label>Priority
+        <input type="number" name="priority" value="{{ old('priority', $task->priority) }}">
+    </label><br>
+    <label>Assignee ID
+        <input type="number" name="assignee_id" value="{{ old('assignee_id', $task->assignee_id) }}">
+    </label><br>
+    <label>Due At
+        <input type="date" name="due_at" value="{{ old('due_at', optional($task->due_at)->format('Y-m-d')) }}">
+    </label><br>
+    <button type="submit">Save</button>
+</form>
+<form method="post" action="{{ route('projects.tasks.destroy', [$project, $task]) }}">
+    @csrf
+    @method('DELETE')
+    <button type="submit">Delete</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,8 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\InstallController;
 use App\Http\Controllers\ClientController;
+use App\Http\Controllers\ProjectController;
+use App\Http\Controllers\TaskController;
 
 Route::get('/', function () {
     if (!file_exists(storage_path('installed.lock'))) {
@@ -18,3 +20,5 @@ Route::post('/install', [InstallController::class, 'store']);
 
 Route::resource('clients', ClientController::class);
 Route::post('clients/{client}/activities', [ClientController::class, 'storeActivity'])->name('clients.activities.store');
+Route::resource('projects', ProjectController::class);
+Route::resource('projects.tasks', TaskController::class)->except(['index', 'create', 'show']);


### PR DESCRIPTION
## Summary
- add projects and tasks tables with status, priority and ownership fields
- implement Project and Task models, controllers and CRUD routes
- show project tasks in a simple Kanban board with basic styling

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689a67e7c3bc83229a71a82bfadbf341