### PR TITLE
Add secure file upload with signed download links

### DIFF
--- a/app/Http/Controllers/FileController.php
+++ b/app/Http/Controllers/FileController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class FileController extends Controller
+{
+    public function create()
+    {
+        return view('files.upload');
+    }
+
+    public function store(Request $request)
+    {
+        $maxKb = config('app.file_max_size_mb', 5) * 1024;
+
+        $request->validate([
+            'file' => ['required', 'file', 'max:' . $maxKb],
+            'owner_type' => ['nullable', 'string'],
+            'owner_id' => ['nullable', 'integer'],
+        ]);
+
+        $uploaded = $request->file('file');
+        $storedName = Str::uuid()->toString();
+        if ($extension = $uploaded->getClientOriginalExtension()) {
+            $storedName .= '.' . $extension;
+        }
+        $uploaded->storeAs('uploads', $storedName);
+
+        $file = File::create([
+            'owner_type' => $request->input('owner_type', Auth::user()->getMorphClass()),
+            'owner_id' => $request->input('owner_id', Auth::id()),
+            'original_name' => $uploaded->getClientOriginalName(),
+            'stored_name' => $storedName,
+            'mime' => $uploaded->getClientMimeType(),
+            'size' => $uploaded->getSize(),
+            'hash' => hash_file('sha256', $uploaded->getRealPath()),
+            'uploader_id' => Auth::id(),
+            'created_at' => now(),
+        ]);
+
+        return response()->json(['id' => $file->id]);
+    }
+
+    public function download(Request $request, File $file)
+    {
+        if (!$request->hasValidSignature()) {
+            abort(403);
+        }
+
+        return Storage::download('uploads/' . $file->stored_name, $file->original_name);
+    }
+}

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\URL;
+
+class File extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'owner_type',
+        'owner_id',
+        'original_name',
+        'stored_name',
+        'mime',
+        'size',
+        'hash',
+        'uploader_id',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function owner(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploader_id');
+    }
+
+    public function temporaryUrl(): string
+    {
+        return URL::temporarySignedRoute('files.download', now()->addMinutes(5), ['file' => $this->id]);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -22,4 +22,6 @@ return [
         'App' => Illuminate\Support\Facades\App::class,
         'Route' => Illuminate\Support\Facades\Route::class,
     ],
+
+    'file_max_size_mb' => env('FILE_MAX_SIZE_MB', 5),
 ];

--- a/database/migrations/2024_01_01_030000_create_files_table.php
+++ b/database/migrations/2024_01_01_030000_create_files_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table->string('owner_type');
+            $table->unsignedBigInteger('owner_id');
+            $table->string('original_name');
+            $table->string('stored_name');
+            $table->string('mime', 255)->nullable();
+            $table->unsignedBigInteger('size');
+            $table->string('hash', 64);
+            $table->foreignId('uploader_id')->constrained('users');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('files');
+    }
+};

--- a/resources/views/files/upload.blade.php
+++ b/resources/views/files/upload.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.css" integrity="sha512-TZLzYqS+V1A1dEB+lD1I7sH++FEkmiJYcaUFNjZ1pnoUQApbkBHB6DNuFf0zPWAIymFcpnSUsctNk6mAQmtWYw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<form action="{{ route('files.store') }}" class="dropzone" id="file-dropzone" enctype="multipart/form-data">
+    @csrf
+    <input type="hidden" name="owner_type" value="{{ auth()->user()->getMorphClass() }}">
+    <input type="hidden" name="owner_id" value="{{ auth()->id() }}">
+</form>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js" integrity="sha512-3g7VmZ4hvs5IrGValutMS8SiHQm5jk+UY69ObZ1srO2Qd6hw2yYB9H9n1tFoZT3zh0+BTtPlqvGjNFH6G+j1NA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+Dropzone.options.fileDropzone = {
+    paramName: 'file',
+    maxFilesize: {{ config('app.file_max_size_mb') }},
+};
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\InstallController;
 use App\Http\Controllers\ClientController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\TaskController;
+use App\Http\Controllers\FileController;
 
 Route::get('/', function () {
     if (!file_exists(storage_path('installed.lock'))) {
@@ -23,3 +24,9 @@ Route::post('clients/{client}/activities', [ClientController::class, 'storeActiv
 Route::resource('projects', ProjectController::class);
 Route::resource('projects.tasks', TaskController::class)->except(['index', 'create', 'show']);
 Route::post('projects/{project}/tasks/{task}/comments', [TaskController::class, 'storeComment'])->name('projects.tasks.comments.store');
+
+Route::middleware('auth')->group(function () {
+    Route::get('files/upload', [FileController::class, 'create'])->name('files.create');
+    Route::post('files', [FileController::class, 'store'])->name('files.store');
+    Route::get('files/{file}/download', [FileController::class, 'download'])->name('files.download')->middleware('signed');
+});


### PR DESCRIPTION
## Summary
- add migration and model for storing uploaded file metadata
- implement authenticated upload and signed download controller routes
- provide Dropzone-based view for drag-and-drop uploads and configurable size limits

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `./vendor/bin/pint` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689a6a473d0c8322844b97f22014cc51