### PR TITLE
Add installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ Minimal Laravel 11 skeleton prepared for shared hosting on LiteSpeed/cPanel.
 ## Deployment on cPanel + LiteSpeed
 
 1. Upload the project files to your cPanel account, usually under `~/`.
-2. Run `composer install` from the terminal or cPanel's Composer feature.
-3. Copy `.env.example` to `.env` and fill in database and SMTP credentials.
-4. Generate the application key with `php artisan key:generate`.
-5. Point the domain's document root to `public_html/public`.
-6. Ensure `storage` and `bootstrap/cache` directories are writable.
-7. Run database migrations and seeds: `php artisan migrate --seed`.
-8. Optionally set up a cron job for the scheduler: `* * * * * php /home/USER/public_html/artisan schedule:run`.
+2. Run `php install.php` to install Composer dependencies and generate the application key.
+3. Copy `.env.example` to `.env` (the installer creates it if missing) and fill in database and SMTP credentials.
+4. Point the domain's document root to `public_html/public`.
+5. Ensure `storage` and `bootstrap/cache` directories are writable.
+6. Run database migrations and seeds: `php artisan migrate --seed`.
+7. Optionally set up a cron job for the scheduler: `* * * * * php /home/USER/public_html/artisan schedule:run`.

--- a/install.php
+++ b/install.php
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+function run(string $command): void
+{
+    echo "Running: {$command}\n";
+    passthru($command, $status);
+    if ($status !== 0) {
+        fwrite(STDERR, "Command failed with exit code {$status}: {$command}\n");
+        exit($status);
+    }
+}
+
+if (!file_exists('.env') && file_exists('.env.example')) {
+    if (!copy('.env.example', '.env')) {
+        fwrite(STDERR, "Failed to create .env file\n");
+        exit(1);
+    }
+    echo ".env file created from .env.example\n";
+}
+
+run('composer install --no-interaction --prefer-dist');
+run('php artisan key:generate --ansi');
+
+echo "Installation complete.\n";


### PR DESCRIPTION
## Summary
- add `install.php` to run Composer and generate app key
- update deployment docs to use the installer script

## Testing
- `php -l install.php`
- `composer validate --no-check-publish`
- `php install.php` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_689a71fc539c8322934db539baf2e0e3